### PR TITLE
Fixed 'grecaptcha is not defined' error in browser

### DIFF
--- a/reCAPTCHA.AspNetCore/RecaptchaHelper.cs
+++ b/reCAPTCHA.AspNetCore/RecaptchaHelper.cs
@@ -11,7 +11,7 @@ namespace reCAPTCHA.AspNetCore
             var uid = Guid.NewGuid().ToString();
             return new HtmlString($"<div id=\"{uid}\" class=\"g-recaptcha\" data-sitekey=\"{siteKey}\"></div>\r\n" +
                                   "<script>\r\n" +
-                                  $"if (grecaptcha) {{\r\ngrecaptcha.render(\'{uid}\', {{\r\n \'sitekey\' : \'{siteKey}\'\r\n }});\r\n}}\r\n" +
+                                  $"if (typeof grecaptcha !== 'undefined') {{\r\ngrecaptcha.render(\'{uid}\', {{\r\n \'sitekey\' : \'{siteKey}\'\r\n }});\r\n}}\r\n" +
                                   "</script>");
         }
     }


### PR DESCRIPTION
If the reCAPTCHA API script is loaded after the captcha is rendered, the grecaptcha variable isn't declared and throws a 'grepatcha is not defined' error in the browser console.

I fixed this by ensuring the grepatcha variable is declared in addition to being defined before rendering the captcha.