### PR TITLE
IRecaptchaService adds a method for directly passing in a token

### DIFF
--- a/reCAPTCHA.AspNetCore/IRecaptchaService.cs
+++ b/reCAPTCHA.AspNetCore/IRecaptchaService.cs
@@ -9,5 +9,7 @@ namespace reCAPTCHA.AspNetCore
     public interface IRecaptchaService
     {
         Task<RecaptchaResponse> Validate(HttpRequest request, bool antiForgery = true);
+
+        Task<RecaptchaResponse> Validate(string responseCode);
     }
 }


### PR DESCRIPTION
RecaptchaService has implemented Task<RecaptchaResponse> Validate(string responseCode), but the interface does not add this method.