### PR TITLE
Added interface to RecaptcaSettings

### DIFF
--- a/reCAPTCHA.AspNetCore.sln
+++ b/reCAPTCHA.AspNetCore.sln
@@ -34,4 +34,15 @@ Global
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {81A6A8D9-3EB8-47E8-A3BE-FCE4984CCC29}
 	EndGlobalSection
+	GlobalSection(AutomaticVersions) = postSolution
+		UpdateAssemblyVersion = True
+		UpdateAssemblyFileVersion = True
+		UpdateAssemblyInfoVersion = True
+		AssemblyVersionSettings = None.None.None.None
+		AssemblyFileVersionSettings = None.None.None.None
+		AssemblyInfoVersionSettings = None.None.None.None
+		UpdatePackageVersion = False
+		AssemblyInfoVersionType = SettingsVersion
+		InheritWinAppVersionFrom = None
+	EndGlobalSection
 EndGlobal

--- a/reCAPTCHA.AspNetCore/RecaptchaService.cs
+++ b/reCAPTCHA.AspNetCore/RecaptchaService.cs
@@ -14,9 +14,9 @@ namespace reCAPTCHA.AspNetCore
     {
         public static bool UseRecaptchaNet { get; set; } = false;
         public static HttpClient Client { get; private set; }
-        public readonly RecaptchaSettings RecaptchaSettings;
+        public readonly IRecaptchaSettings RecaptchaSettings;
 
-        public RecaptchaService(RecaptchaSettings options)
+        public RecaptchaService(IRecaptchaSettings options)
         {
             RecaptchaSettings = options;
 
@@ -38,7 +38,7 @@ namespace reCAPTCHA.AspNetCore
             Client = client;
         }
 
-        public RecaptchaService(RecaptchaSettings options, HttpClient client)
+        public RecaptchaService(IRecaptchaSettings options, HttpClient client)
         {
             RecaptchaSettings = options;
             Client = client;

--- a/reCAPTCHA.AspNetCore/RecaptchaSettings.cs
+++ b/reCAPTCHA.AspNetCore/RecaptchaSettings.cs
@@ -4,19 +4,26 @@ using System.Text;
 
 namespace reCAPTCHA.AspNetCore
 {
-    public class RecaptchaSettings
+	public interface IRecaptchaSettings
+	{
+		string SecretKey { get; set; }
+		string SiteKey { get; set; }
+		string Version { get; set; }
+	}
+
+    public class RecaptchaSettings: IRecaptchaSettings
     {
-        /// <summary>
-        /// Google Recaptcha Secret Key
-        /// </summary>
+	    /// <summary>
+	    /// Google Recaptcha Secret Key
+	    /// </summary>
         public string SecretKey { get; set; }
-        /// <summary>
-        /// Google Recaptcha Site Key
-        /// </summary>
+	    /// <summary>
+	    /// Google Recaptcha Site Key
+	    /// </summary>
         public string SiteKey { get; set; }
-        /// <summary>
-        /// Google Recaptcha Version
-        /// </summary>
+	    /// <summary>
+	    /// Google Recaptcha Version
+	    /// </summary>
         public string Version { get; set; }
     }
 }


### PR DESCRIPTION
Fixes the "Unable to activate type 'reCAPTCHA.Asp Net Core.Recaptcha Service'. The following constructors are ambiguous" error if you try and use a singleton RecaptcaSettings object instead of an IOptions<RecaptchaSettings> object. 