### PR TITLE
Fixing issue #56 Unable to activate The following constructors are ambiguous.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ services.AddRecaptcha(options =>
 In order to prevent having to copy and paste your site key all over your view files (a nightmare to update later). You can inject your settings from the Startup method by adding the following code to top of your view file:
 
 ```csharp
-@inject IOptions<RecaptchaSettings> RecaptchaSettings
+@inject RecaptchaSettings RecaptchaSettings
 ```
 
 You can then freely include the Recaptcha script inside of forms you wish to vaidate later in your controller (supports multiple forms).
@@ -125,13 +125,6 @@ If you wish to trigger a JavaScript function on callback you can pass a method n
     alert('caw caw caw!');
   }
 </script>
-```
-
-You may find that you need to add a reference to Microsoft.Extensions.Options before you can use IOptions.
-
-```csharp
-@using Microsoft.Extensions.Options
-@using reCAPTCHA.AspNetCore
 ```
 
 You can see a tested example of usage in the [Contact.cshtml](https://github.com/TimothyMeadows/reCAPTCHA.AspNetCore/blob/master/reCAPTCHA.AspNetCore.Example/Views/Home/Contact.cshtml) view. However you will need to configure it with your key information before running yourself. You should also take note of the allowed domains security policy in the Google Recaptcha docs.

--- a/reCAPTCHA.AspNetCore.Example/Startup.cs
+++ b/reCAPTCHA.AspNetCore.Example/Startup.cs
@@ -25,8 +25,8 @@ namespace reCAPTCHA.AspNetCore.Example
             // Or Configure recaptcha via options
             //services.AddRecaptcha(options =>
             //{
-            //    options.SecretKey = "";
-            //    options.SiteKey = "";
+            //    options.SecretKey = "1";
+            //    options.SiteKey = "2";
             //});
         }
 

--- a/reCAPTCHA.AspNetCore.Example/Views/Home/Contact.cshtml
+++ b/reCAPTCHA.AspNetCore.Example/Views/Home/Contact.cshtml
@@ -1,9 +1,8 @@
-﻿@using Microsoft.Extensions.Options
-@using reCAPTCHA.AspNetCore
+﻿@using reCAPTCHA.AspNetCore
 @using reCAPTCHA.AspNetCore.Versions;
 
 @model ContactModel
-@inject IOptions<RecaptchaSettings> RecaptchaSettings
+@inject RecaptchaSettings RecaptchaSettings
 
 @{
     ViewData["Title"] = "Contact";
@@ -26,15 +25,15 @@
 @using (Html.BeginForm("Contact", "Home", FormMethod.Post))
 {
     @Html.ValidationSummary(true)
-    <fieldset>
-        <div class="form-group">
-            @Html.LabelFor(model => model.Message)
-            <br />
-            @Html.TextAreaFor(model => model.Message, new { @class = "form-control", rows = "3", style = "width: 300px;" })
-        </div>
-        <div class="form-group">
-            @(Html.Recaptcha<RecaptchaV2Checkbox>(RecaptchaSettings?.Value))
-        </div>
-        <button id="recaptcha" type="submit" class="btn btn-primary">Submit</button>
-    </fieldset>
+<fieldset>
+    <div class="form-group">
+        @Html.LabelFor(model => model.Message)
+        <br />
+        @Html.TextAreaFor(model => model.Message, new { @class = "form-control", rows = "3", style = "width: 300px;" })
+    </div>
+    <div class="form-group">
+        @(Html.Recaptcha<RecaptchaV2Checkbox>(RecaptchaSettings))
+    </div>
+    <button id="recaptcha" type="submit" class="btn btn-primary">Submit</button>
+</fieldset>
 }

--- a/reCAPTCHA.AspNetCore.Example/reCAPTCHA.AspNetCore.Example.csproj
+++ b/reCAPTCHA.AspNetCore.Example/reCAPTCHA.AspNetCore.Example.csproj
@@ -7,7 +7,4 @@
   <ItemGroup>
     <ProjectReference Include="..\reCAPTCHA.AspNetCore\reCAPTCHA.AspNetCore.csproj" />
   </ItemGroup>
-
-
-
 </Project>

--- a/reCAPTCHA.AspNetCore.Tests/Controllers/HomeController.cs
+++ b/reCAPTCHA.AspNetCore.Tests/Controllers/HomeController.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace reCAPTCHA.AspNetCore.Tests.Controllers
+{
+    public class HomeController : Controller
+    {
+        public HomeController(IRecaptchaService recaptcha)
+        {
+        }
+
+        public IActionResult Index()
+        {
+            return View();
+        }
+    }
+}

--- a/reCAPTCHA.AspNetCore.Tests/RecaptchaFluentConfigurationTests.cs
+++ b/reCAPTCHA.AspNetCore.Tests/RecaptchaFluentConfigurationTests.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace reCAPTCHA.AspNetCore.Tests
+{
+    public class RecaptchaFluentConfigurationTests
+    {
+        private readonly HttpClient _httpClient;
+
+        public RecaptchaFluentConfigurationTests()
+        {
+            var builder = new WebHostBuilder().UseStartup<Startup>();
+            var testServer = new TestServer(builder);
+            _httpClient = testServer.CreateClient();
+        }
+
+        [Fact]
+        public async Task Registering_Recaptcha_Via_Fluent_Configuration_Should_Not_Throw_Exception()
+        {
+            // Arrange
+
+            // Act
+            var response = await _httpClient.GetAsync("/home/index");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/reCAPTCHA.AspNetCore.Tests/RecaptchaJsonSectionConfigurationTests.cs
+++ b/reCAPTCHA.AspNetCore.Tests/RecaptchaJsonSectionConfigurationTests.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace reCAPTCHA.AspNetCore.Tests
+{
+    public class RecaptchaJsonSectionConfigurationTests
+    {
+        private readonly HttpClient _httpClient;
+
+        public RecaptchaJsonSectionConfigurationTests()
+        {
+            var builder = new WebHostBuilder().ConfigureAppConfiguration((hostingContext, config) =>
+            {
+                config.AddJsonFile("appsettings.json", false, true)
+                    .AddEnvironmentVariables();
+            }).UseStartup<Startup2>();
+
+            //var builder2 = Host.CreateDefaultBuilder(new string[] { })
+            //    .ConfigureWebHostDefaults(webBuilder =>
+            //    {
+            //        webBuilder.UseStartup<Startup>();
+            //    }).Build();
+
+            var testServer = new TestServer(builder);
+            _httpClient = testServer.CreateClient();
+        }
+
+        [Fact]
+        public async Task Registering_Recaptcha_Via_Json_Section_Configuration_Should_Not_Throw_Exception()
+        {
+            // Arrange
+
+            // Act
+            var response = await _httpClient.GetAsync("/home/index");
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/reCAPTCHA.AspNetCore.Tests/Startup.cs
+++ b/reCAPTCHA.AspNetCore.Tests/Startup.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace reCAPTCHA.AspNetCore.Tests
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllersWithViews();
+
+            services.AddRecaptcha(options =>
+            {
+                options.SecretKey = "SecretKey";
+                options.SiteKey = "SiteKey";
+            });
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+                app.UseDeveloperExceptionPage();
+
+            app.UseStaticFiles();
+
+            app.UseRouting();
+            app.UseAuthorization();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+    }
+}

--- a/reCAPTCHA.AspNetCore.Tests/Startup2.cs
+++ b/reCAPTCHA.AspNetCore.Tests/Startup2.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace reCAPTCHA.AspNetCore.Tests
+{
+    public class Startup2
+    {
+        public Startup2(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllersWithViews();
+
+            services.AddRecaptcha(Configuration.GetSection("RecaptchaSettings"));
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+                app.UseDeveloperExceptionPage();
+
+            app.UseStaticFiles();
+
+            app.UseRouting();
+            app.UseAuthorization();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllerRoute(
+                    name: "default",
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
+            });
+        }
+    }
+}

--- a/reCAPTCHA.AspNetCore.Tests/Views/Home/Index.cshtml
+++ b/reCAPTCHA.AspNetCore.Tests/Views/Home/Index.cshtml
@@ -1,0 +1,33 @@
+﻿@using reCAPTCHA.AspNetCore
+@using reCAPTCHA.AspNetCore.Versions;
+
+@inject RecaptchaSettings RecaptchaSettings
+
+@{
+    ViewData["Title"] = "Contact";
+}
+<h2>@ViewData["Title"]</h2>
+<h3>@ViewData["Message"]</h3>
+
+<address>
+    One Microsoft Way<br />
+    Redmond, WA 98052-6399<br />
+    <abbr title="Phone">P:</abbr>
+    425.555.0100
+</address>
+
+<address>
+    <strong>Support:</strong> <a href="mailto:Support@example.com">Support@example.com</a><br />
+    <strong>Marketing:</strong> <a href="mailto:Marketing@example.com">Marketing@example.com</a>
+</address>
+
+@using (Html.BeginForm("Index", "Home", FormMethod.Post))
+{
+    @Html.ValidationSummary(true)
+    <fieldset>
+        <div class="form-group">
+            @(Html.Recaptcha<RecaptchaV2Checkbox>(RecaptchaSettings))
+        </div>
+        <button id="recaptcha" type="submit" class="btn btn-primary">Submit</button>
+    </fieldset>
+}

--- a/reCAPTCHA.AspNetCore.Tests/Views/Shared/_Layout.cshtml
+++ b/reCAPTCHA.AspNetCore.Tests/Views/Shared/_Layout.cshtml
@@ -1,0 +1,40 @@
+﻿<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@ViewData["Title"] - reCAPTCHA.AspNetCore.Example</title>
+</head>
+<body>
+    <header>
+        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
+            <div class="container">
+                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">reCAPTCHA.AspNetCore.Example</a>
+                <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
+                        aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
+                    <ul class="navbar-nav flex-grow-1">
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </nav>
+    </header>
+    <div class="container">
+        <main role="main" class="pb-3">
+            @RenderBody()
+        </main>
+    </div>
+
+    <footer class="border-top footer text-muted">
+        <div class="container">
+            &copy; 2020 - reCAPTCHA.AspNetCore.Example - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+        </div>
+    </footer>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/reCAPTCHA.AspNetCore.Tests/Views/_ViewImports.cshtml
+++ b/reCAPTCHA.AspNetCore.Tests/Views/_ViewImports.cshtml
@@ -1,0 +1,1 @@
+﻿@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/reCAPTCHA.AspNetCore.Tests/Views/_ViewStart.cshtml
+++ b/reCAPTCHA.AspNetCore.Tests/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+﻿@{
+    Layout = "_Layout";
+}

--- a/reCAPTCHA.AspNetCore.Tests/appsettings.json
+++ b/reCAPTCHA.AspNetCore.Tests/appsettings.json
@@ -1,0 +1,6 @@
+{
+  "RecaptchaSettings": {
+    "SecretKey": "paste secret key here",
+    "SiteKey": "paste site key here"
+  }
+}

--- a/reCAPTCHA.AspNetCore.Tests/reCAPTCHA.AspNetCore.Tests.csproj
+++ b/reCAPTCHA.AspNetCore.Tests/reCAPTCHA.AspNetCore.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\reCAPTCHA.AspNetCore\reCAPTCHA.AspNetCore.csproj" />
+  </ItemGroup>
+</Project>

--- a/reCAPTCHA.AspNetCore.sln
+++ b/reCAPTCHA.AspNetCore.sln
@@ -5,7 +5,9 @@ VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "reCAPTCHA.AspNetCore", "reCAPTCHA.AspNetCore\reCAPTCHA.AspNetCore.csproj", "{E777B650-E63C-4B58-94A1-892C830CA383}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "reCAPTCHA.AspNetCore.Example", "reCAPTCHA.AspNetCore.Example\reCAPTCHA.AspNetCore.Example.csproj", "{FC3B8908-367B-4220-83B8-8E826AC26AA2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "reCAPTCHA.AspNetCore.Example", "reCAPTCHA.AspNetCore.Example\reCAPTCHA.AspNetCore.Example.csproj", "{FC3B8908-367B-4220-83B8-8E826AC26AA2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "reCAPTCHA.AspNetCore.Tests", "reCAPTCHA.AspNetCore.Tests\reCAPTCHA.AspNetCore.Tests.csproj", "{6A03454A-6319-4B70-832B-B7BCDA818E5F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{FC3B8908-367B-4220-83B8-8E826AC26AA2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC3B8908-367B-4220-83B8-8E826AC26AA2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC3B8908-367B-4220-83B8-8E826AC26AA2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6A03454A-6319-4B70-832B-B7BCDA818E5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6A03454A-6319-4B70-832B-B7BCDA818E5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6A03454A-6319-4B70-832B-B7BCDA818E5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6A03454A-6319-4B70-832B-B7BCDA818E5F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/reCAPTCHA.AspNetCore/RecaptchaServiceCollection.cs
+++ b/reCAPTCHA.AspNetCore/RecaptchaServiceCollection.cs
@@ -46,7 +46,9 @@ namespace reCAPTCHA.AspNetCore
             if (configurationSection == null)
                 throw new ArgumentNullException(nameof(configurationSection));
 
-            services.Configure<RecaptchaSettings>(configurationSection);
+            var recaptchaSettings = new RecaptchaSettings();
+            configurationSection.Bind(recaptchaSettings);
+            services.AddSingleton(recaptchaSettings);
             services.AddTransient<IRecaptchaService, RecaptchaService>();
 
             return services;


### PR DESCRIPTION
Fixing TimothyMeadows/reCAPTCHA.AspNetCore#56. I removed dependency on `IOptions` hence it's no longer required. Also, I added two integration tests to validate Recaptcha service registration via `IConfiguration` section and fluent configuration.