### PR TITLE
Add property for enabled/disabled async in recaptcha script

### DIFF
--- a/reCAPTCHA.AspNetCore/Templates/RecaptchaV3HiddenInput.tt
+++ b/reCAPTCHA.AspNetCore/Templates/RecaptchaV3HiddenInput.tt
@@ -5,7 +5,7 @@
 <#@ import namespace="System.Collections.Generic" #>
 
 <input id="<#= Model.Id #>" name="g-recaptcha-response" type="hidden" value="" />
-<script <# if (!string.IsNullOrEmpty(Model.Settings.ContentSecurityPolicy)) {#>script-src="<#= Model.Settings.ContentSecurityPolicy #>"<#}#> <# if (!string.IsNullOrEmpty(Model.Settings.ContentSecurityPolicy)) {#>frame-src="<#= Model.Settings.ContentSecurityPolicy #>"<#}#> src="https://<#= Model.Settings.Site #>/recaptcha/api.js?render=<#= Model.Settings.SiteKey #>&hl=<#= Model.Language #>" async defer></script>
+<script <# if (!string.IsNullOrEmpty(Model.Settings.ContentSecurityPolicy)) {#>script-src="<#= Model.Settings.ContentSecurityPolicy #>"<#}#> <# if (!string.IsNullOrEmpty(Model.Settings.ContentSecurityPolicy)) {#>frame-src="<#= Model.Settings.ContentSecurityPolicy #>"<#}#> src="https://<#= Model.Settings.Site #>/recaptcha/api.js?render=<#= Model.Settings.SiteKey #>&hl=<#= Model.Language #>" <# if (Model.IsAsync) {#>async defer<#}#> ></script>
 <script>
 	if (typeof grecaptcha !== 'undefined') {
 		grecaptcha.ready(function () {

--- a/reCAPTCHA.AspNetCore/Versions/RecaptchaV3HiddenInput.cs
+++ b/reCAPTCHA.AspNetCore/Versions/RecaptchaV3HiddenInput.cs
@@ -8,5 +8,6 @@ namespace reCAPTCHA.AspNetCore.Versions
     {
         public string Id { get; set; } = "g-recaptcha-response";
         public string Action { get; set; } = "homepage";
+        public bool IsAsync { get; set; } = true;
     }
 }


### PR DESCRIPTION
When adding recaptcha 3 to my site, I encountered a problem that the token was not loaded into the input. After investigating the problem, I realized that the problem is in asynchronous loading of scripts, and somehow they do not have time to load before the page is loaded, this became a problem for me, and I added a solution that disables asynchronous loading by choice in the model.