### PR TITLE
Cache result

### DIFF
--- a/reCAPTCHA.AspNetCore.Example/Controllers/HomeController.cs
+++ b/reCAPTCHA.AspNetCore.Example/Controllers/HomeController.cs
@@ -85,7 +85,7 @@ namespace reCAPTCHA.AspNetCore.Example.Controllers
         [ValidateRecaptcha(0.5)]
         public IActionResult Contact4(ContactModel model)
         {
-            ViewData["Message"] = "Your contact page.";
+            ViewData["Message"] = $"Your contact page with a reCAPTCHA score of {Request.GetCachedRecaptchaResponse().score}.";
 
             return View(!ModelState.IsValid ? model : new ContactModel());
         }

--- a/reCAPTCHA.AspNetCore/Attributes/RecaptchaResponseAttribute.cs
+++ b/reCAPTCHA.AspNetCore/Attributes/RecaptchaResponseAttribute.cs
@@ -44,7 +44,7 @@ namespace reCAPTCHA.AspNetCore.Attributes
 
 			var validationservice = validationContext.GetService<IRecaptchaService>();
 
-            if(validationservice is null)
+            if (validationservice is null)
                 throw new ConfigurationErrorsException($"{typeof(IRecaptchaService).Assembly.GetName().Name} has not been configured");
 
 			var response = validationservice.Validate(responseCode).Result;

--- a/reCAPTCHA.AspNetCore/HttpContextExtensions.cs
+++ b/reCAPTCHA.AspNetCore/HttpContextExtensions.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace reCAPTCHA.AspNetCore
+{
+    public static class HttpContextExtensions
+    {
+        public static RecaptchaResponse GetCachedRecaptchaResponse(this HttpRequest request) =>
+            request.HttpContext.Items["RecaptchaResponse"] as RecaptchaResponse;
+    }
+}

--- a/reCAPTCHA.AspNetCore/RecaptchaService.cs
+++ b/reCAPTCHA.AspNetCore/RecaptchaService.cs
@@ -22,9 +22,9 @@ namespace reCAPTCHA.AspNetCore
             if (!request.Form.ContainsKey("g-recaptcha-response")) // error if no reason to do anything, this is to alert developers they are calling it without reason.
                 throw new ValidationException("Google recaptcha response not found in form. Did you forget to include it?");
 
-            var response = request.Form["g-recaptcha-response"];
-            var result = await Client.GetStringAsync($"https://{RecaptchaSettings.Site}/recaptcha/api/siteverify?secret={RecaptchaSettings.SecretKey}&response={response}");
-            var captchaResponse = JsonSerializer.Deserialize<RecaptchaResponse>(result);
+            if (request.GetCachedRecaptchaResponse() == null)
+                request.HttpContext.Items["RecaptchaResponse"] = await Validate(request.Form["g-recaptcha-response"]);
+            RecaptchaResponse captchaResponse = request.GetCachedRecaptchaResponse();
 
             if (captchaResponse.success && antiForgery)
                 if (captchaResponse.hostname?.ToLower() != request.Host.Host?.ToLower() && captchaResponse.hostname != "testkey.google.com")

--- a/reCAPTCHA.AspNetCore/RecaptchaService.cs
+++ b/reCAPTCHA.AspNetCore/RecaptchaService.cs
@@ -35,13 +35,11 @@ namespace reCAPTCHA.AspNetCore
 
         public async Task<RecaptchaResponse> Validate(string responseCode)
         {
-            if (string.IsNullOrEmpty(responseCode))
-                throw new ValidationException("Google recaptcha response is empty?");
-
-            var result = await Client.GetStringAsync($"https://{RecaptchaSettings.Site}/recaptcha/api/siteverify?secret={RecaptchaSettings.SecretKey}&response={responseCode}");
-            var captchaResponse = JsonSerializer.Deserialize<RecaptchaResponse>(result);
-
-            return captchaResponse;
+            if (string.IsNullOrWhiteSpace(responseCode))
+                throw new ValidationException("Google reCAPTCHA response is empty");
+            string result = await Client.GetStringAsync(
+                $"https://{RecaptchaSettings.Site}/recaptcha/api/siteverify?secret={RecaptchaSettings.SecretKey}&response={responseCode}");
+            return JsonSerializer.Deserialize<RecaptchaResponse>(result);
         }
     }
 }


### PR DESCRIPTION
Allow to access result of Validate

Cache the result of Validate in the HttpContext for the current request.
This prevents the need for another request to the provider when one needs to access the score after using an attribute to check it already. This could allow a controller action that validates the score is at least 0.5 but then also saves that score into a database or attaches it to an email. 